### PR TITLE
bug fix for forward_spectrogram

### DIFF
--- a/dasheng/pretrained/pretrained.py
+++ b/dasheng/pretrained/pretrained.py
@@ -43,8 +43,9 @@ class Dasheng(AudioTransformerMAE_Encoder):
                                   device=x.device)
                 pad[..., :splits[-1].shape[-1]] = splits[-1]
                 padding_start_in_chunks = splits[-1].shape[-1] // self.patch_stride[-1]
-                splits = torch.stack((*splits[:-1], pad), dim=0)
+                splits = (*splits[:-1], pad)
             n_splits = len(splits)
+            splits = torch.stack(splits, dim=0)
             # Splits into the batch_size, speeds up computation
             x = rearrange(splits, 'spl b c f t-> (spl b) c f t')
             x = self.forward_features(x)


### PR DESCRIPTION
在处理大于10s的音频的时候，原代码通过`splits = x.split(self.target_length, -1)`得到的`tuple`的最后一个slice的长度作为是否padding的判断标准。但是对于恰好最后一个slice长度为`self.target_length`的音频，并没有把splits这个tuple再stack成tensor，导致之后对tensor的操作出现type error的bug。因为`self.target_length=1008`，因此出现概率比较小，我也是在跑测试的时候发现的。

我使用的是`python==3.10  torch==2.4.1`，不确定其他版本会不会出现这样的bug，但是保险一点总没错（