### PR TITLE
Pushed to version 0.0.8, added support for variable length inputs (batched)

### DIFF
--- a/dasheng/pretrained/pretrained.py
+++ b/dasheng/pretrained/pretrained.py
@@ -1,87 +1,86 @@
 import torch
+from typing import Optional
 from einops import rearrange
 from ..train.models import AudioTransformerMAE_Encoder
 
 PRETRAINED_CHECKPOINTS = {
-    'dasheng_base':
-    'https://zenodo.org/records/11511780/files/dasheng_base.pt?download=1',
-    'dasheng_06B':
-    'https://zenodo.org/records/11511780/files/dasheng_06b.pt?download=1',
-    'dasheng_12B':
-    'https://zenodo.org/records/11511780/files/dasheng_12b.pt?download=1',
+    "dasheng_base": "https://zenodo.org/records/11511780/files/dasheng_base.pt?download=1",
+    "dasheng_06B": "https://zenodo.org/records/11511780/files/dasheng_06b.pt?download=1",
+    "dasheng_12B": "https://zenodo.org/records/11511780/files/dasheng_12b.pt?download=1",
 }
 
 
-#Using the pretrained encoders, remove all masking
+# Using the pretrained encoders, remove all masking
 class Dasheng(AudioTransformerMAE_Encoder):
-
     # need the *args, **kwargs otherwise we get a linter warning
-    def forward_features(self, x: torch.Tensor, *args,
-                         **kwargs) -> torch.Tensor:
-        x = self.patch_embed(x)
+    def forward_features(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         *_, t = x.shape
         x = x + self.time_pos_embed[:, :, :, :t]
         x = x + self.freq_pos_embed[:, :, :, :]
-        x = rearrange(x, 'b c f t -> b (f t) c')
-        if self.pooling == 'token':
+        x = rearrange(x, "b c f t -> b (f t) c")
+        if self.pooling == "token":
             cls_token = self.cls_token.expand(x.shape[0], -1, -1)
             cls_token = cls_token + self.token_pos_embed[:, :]
             x = torch.cat((cls_token, x), dim=1)
         x = self.pos_drop(x)
-        x = self.blocks(x)
+        x = self.blocks(x, **kwargs)
         x = self.norm(x)
         return x
 
-    def forward_spectrogram(self, x: torch.Tensor) -> torch.Tensor:
-        if x.shape[-1] > self.target_length:
-            splits = x.split(self.target_length, -1)
+    def _to_mask(self, lengths: torch.Tensor, max_length: int) -> torch.Tensor:
+        batch_size = len(lengths)
+        idx = torch.arange(max_length, device=lengths.device)
+        idx = idx.repeat(batch_size).view(batch_size, max_length)
+        mask = (idx >= lengths.unsqueeze(-1)).bool()
+        return mask
 
-            padding_start_in_chunks = 0
-            if len(splits) > 1 and (splits[-1].shape[-1] < self.target_length):
-                pad = torch.zeros(*x.shape[:-1],
-                                  self.target_length,
-                                  device=x.device)
-                pad[..., :splits[-1].shape[-1]] = splits[-1]
-                padding_start_in_chunks = splits[-1].shape[-1] // self.patch_stride[-1]
-                splits = torch.stack((*splits[:-1], pad), dim=0)
-            else:
-                splits = torch.stack(splits, dim=0)
-            n_splits = len(splits)
-            splits = torch.stack(splits, dim=0)
-            # Splits into the batch_size, speeds up computation
-            x = rearrange(splits, 'spl b c f t-> (spl b) c f t')
-            x = self.forward_features(x)
-            x = rearrange(x, '(spl b) ... d -> spl b (...) d', spl=n_splits)
-            # Trim last chunk
-            if padding_start_in_chunks > 0:
-                not_padded = rearrange(x[:-1], 'spl b ... d -> b (spl ...) d')
-                padded = x[-1][:, :padding_start_in_chunks, ...]
-                x = torch.cat((not_padded, padded), dim=1)
-            else:
-                x = rearrange(x, 'spl b ... d -> b (spl ...) d', spl=n_splits)
-            return x
-        else:
-            return self.forward_features(x)
+    def forward_spectrogram(self, x: torch.Tensor, x_length:Optional[torch.Tensor] = None) -> torch.Tensor:
+        # For dasheng, target-length is 40 ms
+        target_length_in_patches = self.target_length // self.patch_stride[-1]
+        x = self.patch_embed(x)
+        b, c, f, t = x.shape
+        input_splits = x.split(target_length_in_patches, dim=-1)
+        mask = None # Single mask
+        masks = [None for _ in range(len(input_splits))]
+        if x_length is not None:
+            assert len(x_length) == len(x),"batchsizes of input x and x_length need to be same"
+            assert x_length.ndim == 1, "Lengths are of size (B,)"
+            scaled_lengths = (x_length / (self.hop_size * 4)).long() # 40ms for all dasheng models
+            # Note that the mask is in (t f) format, but transformers here use (f t) format
+            mask = self._to_mask(
+                max_length=t,
+                lengths=scaled_lengths,
+                )
+            # Trim mask to only use valid "patches", since x.shape[-1] is based on the possibly padded input
+            masks = mask.split(target_length_in_patches, dim=-1)
+        outputs = []
+
+        for split_x,mask in zip(input_splits, masks):
+            forward_kwargs = dict(mask = mask)
+            split_x = self.forward_features(split_x, **forward_kwargs)
+            outputs.append(split_x)
+        x = torch.cat(outputs, dim =1 )
+        return x
 
 
-
-    def forward(self, x, *args, **kwargs) -> torch.Tensor:
+    def forward(self, x, x_length : Optional[torch.Tensor] = None) -> torch.Tensor:
         x = self.forward_to_spec(x)
-        return self.forward_spectrogram(x)
+        return self.forward_spectrogram(x,x_length=x_length)
 
     @classmethod
     def from_pretrained(
-            cls, pretrained_url: str,
-            **additional_model_kwargs) -> AudioTransformerMAE_Encoder:
+        cls, pretrained_url: str, **additional_model_kwargs
+    ) -> AudioTransformerMAE_Encoder:
         """
         Class method to create a new Dasheng model instance from a pre-trained model stored in the Hugging Face model hub.
         """
-        if 'http' in pretrained_url:
-            dump = torch.hub.load_state_dict_from_url(pretrained_url,
-                                                      map_location='cpu')
+        if "http" in pretrained_url:
+            dump = torch.hub.load_state_dict_from_url(
+                pretrained_url, map_location="cpu"
+            )
         else:
-            dump = torch.load(pretrained_url, map_location='cpu')
-        model_parmeters, model_config = dump['model'], dump['config']
+            dump = torch.load(pretrained_url, map_location="cpu")
+        model_parmeters, model_config = dump["model"], dump["config"]
         instance = cls(**{**model_config, **additional_model_kwargs})
         instance.load_state_dict(model_parmeters, strict=True)
         return instance
@@ -91,24 +90,27 @@ def dasheng_base(**model_kwargs):
     model_kwargs["embed_dim"] = 768
     model_kwargs["depth"] = 12
     model_kwargs["num_heads"] = 12
-    return Dasheng.from_pretrained(PRETRAINED_CHECKPOINTS['dasheng_base'],
-                                   **model_kwargs)
+    return Dasheng.from_pretrained(
+        PRETRAINED_CHECKPOINTS["dasheng_base"], **model_kwargs
+    )
 
 
 def dasheng_06B(**model_kwargs):
     model_kwargs["embed_dim"] = 1280
     model_kwargs["depth"] = 32
     model_kwargs["num_heads"] = 16
-    return Dasheng.from_pretrained(PRETRAINED_CHECKPOINTS['dasheng_06B'],
-                                   **model_kwargs)
+    return Dasheng.from_pretrained(
+        PRETRAINED_CHECKPOINTS["dasheng_06B"], **model_kwargs
+    )
 
 
 def dasheng_12B(**model_kwargs):
     model_kwargs["embed_dim"] = 1536
     model_kwargs["depth"] = 40
     model_kwargs["num_heads"] = 24
-    return Dasheng.from_pretrained(PRETRAINED_CHECKPOINTS['dasheng_12B'],
-                                   **model_kwargs)
+    return Dasheng.from_pretrained(
+        PRETRAINED_CHECKPOINTS["dasheng_12B"], **model_kwargs
+    )
 
 
 if __name__ == "__main__":

--- a/dasheng/pretrained/pretrained.py
+++ b/dasheng/pretrained/pretrained.py
@@ -1,86 +1,86 @@
 import torch
+from typing import Optional
 from einops import rearrange
 from ..train.models import AudioTransformerMAE_Encoder
 
 PRETRAINED_CHECKPOINTS = {
-    'dasheng_base':
-    'https://zenodo.org/records/11511780/files/dasheng_base.pt?download=1',
-    'dasheng_06B':
-    'https://zenodo.org/records/11511780/files/dasheng_06b.pt?download=1',
-    'dasheng_12B':
-    'https://zenodo.org/records/11511780/files/dasheng_12b.pt?download=1',
+    "dasheng_base": "https://zenodo.org/records/11511780/files/dasheng_base.pt?download=1",
+    "dasheng_06B": "https://zenodo.org/records/11511780/files/dasheng_06b.pt?download=1",
+    "dasheng_12B": "https://zenodo.org/records/11511780/files/dasheng_12b.pt?download=1",
 }
 
 
-#Using the pretrained encoders, remove all masking
+# Using the pretrained encoders, remove all masking
 class Dasheng(AudioTransformerMAE_Encoder):
-
     # need the *args, **kwargs otherwise we get a linter warning
-    def forward_features(self, x: torch.Tensor, *args,
-                         **kwargs) -> torch.Tensor:
-        x = self.patch_embed(x)
+    def forward_features(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         *_, t = x.shape
         x = x + self.time_pos_embed[:, :, :, :t]
         x = x + self.freq_pos_embed[:, :, :, :]
-        x = rearrange(x, 'b c f t -> b (f t) c')
-        if self.pooling == 'token':
+        x = rearrange(x, "b c f t -> b (f t) c")
+        if self.pooling == "token":
             cls_token = self.cls_token.expand(x.shape[0], -1, -1)
             cls_token = cls_token + self.token_pos_embed[:, :]
             x = torch.cat((cls_token, x), dim=1)
         x = self.pos_drop(x)
-        x = self.blocks(x)
+        x = self.blocks(x, **kwargs)
         x = self.norm(x)
         return x
 
-    def forward_spectrogram(self, x: torch.Tensor) -> torch.Tensor:
-        if x.shape[-1] > self.target_length:
-            splits = x.split(self.target_length, -1)
+    def _to_mask(self, lengths: torch.Tensor, max_length: int) -> torch.Tensor:
+        batch_size = len(lengths)
+        idx = torch.arange(max_length, device=lengths.device)
+        idx = idx.repeat(batch_size).view(batch_size, max_length)
+        mask = (idx >= lengths.unsqueeze(-1)).bool()
+        return mask
 
-            padding_start_in_chunks = 0
-            if len(splits) > 1 and (splits[-1].shape[-1] < self.target_length):
-                pad = torch.zeros(*x.shape[:-1],
-                                  self.target_length,
-                                  device=x.device)
-                pad[..., :splits[-1].shape[-1]] = splits[-1]
-                padding_start_in_chunks = splits[-1].shape[-1] // self.patch_stride[-1]
-                splits = torch.stack((*splits[:-1], pad), dim=0)
-            else:
-                splits = torch.stack(splits, dim=0)
-            n_splits = len(splits)
-            # Splits into the batch_size, speeds up computation
-            x = rearrange(splits, 'spl b c f t-> (spl b) c f t')
-            x = self.forward_features(x)
-            x = rearrange(x, '(spl b) ... d -> spl b (...) d', spl=n_splits)
-            # Trim last chunk
-            if padding_start_in_chunks > 0:
-                not_padded = rearrange(x[:-1], 'spl b ... d -> b (spl ...) d')
-                padded = x[-1][:, :padding_start_in_chunks, ...]
-                x = torch.cat((not_padded, padded), dim=1)
-            else:
-                x = rearrange(x, 'spl b ... d -> b (spl ...) d', spl=n_splits)
-            return x
-        else:
-            return self.forward_features(x)
+    def forward_spectrogram(self, x: torch.Tensor, x_length:Optional[torch.Tensor] = None) -> torch.Tensor:
+        # For dasheng, target-length is 40 ms
+        target_length_in_patches = self.target_length // self.patch_stride[-1]
+        x = self.patch_embed(x)
+        b, c, f, t = x.shape
+        input_splits = x.split(target_length_in_patches, dim=-1)
+        mask = None # Single mask
+        masks = [None for _ in range(len(input_splits))]
+        if x_length is not None:
+            assert len(x_length) == len(x),"batchsizes of input x and x_length need to be same"
+            assert x_length.ndim == 1, "Lengths are of size (B,)"
+            scaled_lengths = (x_length / (self.hop_size * 4)).long() # 40ms for all dasheng models
+            # Note that the mask is in (t f) format, but transformers here use (f t) format
+            mask = self._to_mask(
+                max_length=t,
+                lengths=scaled_lengths,
+                )
+            # Trim mask to only use valid "patches", since x.shape[-1] is based on the possibly padded input
+            masks = mask.split(target_length_in_patches, dim=-1)
+        outputs = []
+
+        for split_x,mask in zip(input_splits, masks):
+            forward_kwargs = dict(mask = mask)
+            split_x = self.forward_features(split_x, **forward_kwargs)
+            outputs.append(split_x)
+        x = torch.cat(outputs, dim =1 )
+        return x
 
 
-
-    def forward(self, x, *args, **kwargs) -> torch.Tensor:
+    def forward(self, x, x_length : Optional[torch.Tensor] = None) -> torch.Tensor:
         x = self.forward_to_spec(x)
-        return self.forward_spectrogram(x)
+        return self.forward_spectrogram(x,x_length=x_length)
 
     @classmethod
     def from_pretrained(
-            cls, pretrained_url: str,
-            **additional_model_kwargs) -> AudioTransformerMAE_Encoder:
+        cls, pretrained_url: str, **additional_model_kwargs
+    ) -> AudioTransformerMAE_Encoder:
         """
         Class method to create a new Dasheng model instance from a pre-trained model stored in the Hugging Face model hub.
         """
-        if 'http' in pretrained_url:
-            dump = torch.hub.load_state_dict_from_url(pretrained_url,
-                                                      map_location='cpu')
+        if "http" in pretrained_url:
+            dump = torch.hub.load_state_dict_from_url(
+                pretrained_url, map_location="cpu"
+            )
         else:
-            dump = torch.load(pretrained_url, map_location='cpu')
-        model_parmeters, model_config = dump['model'], dump['config']
+            dump = torch.load(pretrained_url, map_location="cpu")
+        model_parmeters, model_config = dump["model"], dump["config"]
         instance = cls(**{**model_config, **additional_model_kwargs})
         instance.load_state_dict(model_parmeters, strict=True)
         return instance
@@ -90,24 +90,27 @@ def dasheng_base(**model_kwargs):
     model_kwargs["embed_dim"] = 768
     model_kwargs["depth"] = 12
     model_kwargs["num_heads"] = 12
-    return Dasheng.from_pretrained(PRETRAINED_CHECKPOINTS['dasheng_base'],
-                                   **model_kwargs)
+    return Dasheng.from_pretrained(
+        PRETRAINED_CHECKPOINTS["dasheng_base"], **model_kwargs
+    )
 
 
 def dasheng_06B(**model_kwargs):
     model_kwargs["embed_dim"] = 1280
     model_kwargs["depth"] = 32
     model_kwargs["num_heads"] = 16
-    return Dasheng.from_pretrained(PRETRAINED_CHECKPOINTS['dasheng_06B'],
-                                   **model_kwargs)
+    return Dasheng.from_pretrained(
+        PRETRAINED_CHECKPOINTS["dasheng_06B"], **model_kwargs
+    )
 
 
 def dasheng_12B(**model_kwargs):
     model_kwargs["embed_dim"] = 1536
     model_kwargs["depth"] = 40
     model_kwargs["num_heads"] = 24
-    return Dasheng.from_pretrained(PRETRAINED_CHECKPOINTS['dasheng_12B'],
-                                   **model_kwargs)
+    return Dasheng.from_pretrained(
+        PRETRAINED_CHECKPOINTS["dasheng_12B"], **model_kwargs
+    )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'dasheng'
-version = '0.0.7'
+version = '0.0.8'
 dependencies = [
     "einops",
     "numpy",


### PR DESCRIPTION
Added training/inference support with variable lengths (aka masking).


```python
import torch
from dasheng import dasheng_base
wav = torch.randn(3, 160000)

length = wav.shape[-1]
padded_wav = torch.nn.functional.pad(wav, (0, 1600000))

mdl = dasheng_base()
mdl = mdl.eval()


with torch.no_grad():
    y1 = mdl(padded_wav, x_length = torch.tensor([length] * wav.shape[0]))
    y2 = mdl(wav)
    print(y1.shape, y2.shape)
    print((y1[:,:248] - y2[:,:248]).max())
```
Result is usually around `0.0060`, which is acceptable ( due to mel frames seeing padding)