### PR TITLE
Allow for a path= argument in loading models to skip the downloading process

### DIFF
--- a/dasheng/pretrained/pretrained.py
+++ b/dasheng/pretrained/pretrained.py
@@ -86,30 +86,30 @@ class Dasheng(AudioTransformerMAE_Encoder):
         return instance
 
 
-def dasheng_base(**model_kwargs):
+def dasheng_base(path = None, **model_kwargs):
     model_kwargs["embed_dim"] = 768
     model_kwargs["depth"] = 12
     model_kwargs["num_heads"] = 12
     return Dasheng.from_pretrained(
-        PRETRAINED_CHECKPOINTS["dasheng_base"], **model_kwargs
+        pretrained_url=path or PRETRAINED_CHECKPOINTS["dasheng_base"], **model_kwargs
     )
 
 
-def dasheng_06B(**model_kwargs):
+def dasheng_06B(path = None, **model_kwargs):
     model_kwargs["embed_dim"] = 1280
     model_kwargs["depth"] = 32
     model_kwargs["num_heads"] = 16
     return Dasheng.from_pretrained(
-        PRETRAINED_CHECKPOINTS["dasheng_06B"], **model_kwargs
+        pretrained_url=path or PRETRAINED_CHECKPOINTS["dasheng_06B"], **model_kwargs
     )
 
 
-def dasheng_12B(**model_kwargs):
+def dasheng_12B(path = None, **model_kwargs):
     model_kwargs["embed_dim"] = 1536
     model_kwargs["depth"] = 40
     model_kwargs["num_heads"] = 24
     return Dasheng.from_pretrained(
-        PRETRAINED_CHECKPOINTS["dasheng_12B"], **model_kwargs
+        pretrained_url=path or PRETRAINED_CHECKPOINTS["dasheng_12B"], **model_kwargs
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'dasheng'
-version = '0.0.8'
+version = '0.0.9'
 dependencies = [
     "einops",
     "numpy",


### PR DESCRIPTION
Users can pass `dasheng_base(path="CHECKPOINT")` to skip the downloading process.